### PR TITLE
Remove Dependabot auto-approve step from workflow.

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,15 +17,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve semver patch/minor updates
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge for semver patch/minor
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
Required approvals is 0 and GitHub Actions cannot approve PRs by default, so the approve step only caused CI failures.